### PR TITLE
2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Order callbacks allow your Prestashop site to automatically process order status
 
 ## Changelog
 
-### 2.1.0 (14/02/2025):
+### 2.1.0 (17/02/2025):
 
 _Added_ support for new JSON and old URL-encoded form data callbacks format. New callbacks will be automatically enabled with new SpectroCoin merchant projects created. With old projects, old callback format will be used. In the future versions old callback format will be removed.
 

--- a/controllers/front/callback.php
+++ b/controllers/front/callback.php
@@ -89,8 +89,8 @@ class SpectrocoinCallbackModuleFrontController extends ModuleFrontController
                 $statusRaw  = $cb->getStatus();
             }
             $history            = new OrderHistory();
-            $history->id_order  = (int) $orderIdRaw;
-
+            $orderId = explode('-', $orderIdRaw, 2)[0];
+            $history->id_order  = (int) $orderId;
             $statusEnum = OrderStatus::normalize($statusRaw);
 
             switch ($statusEnum) {

--- a/controllers/front/redirect.php
+++ b/controllers/front/redirect.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SpectroCoin Module
  *
@@ -22,6 +23,7 @@
  * @copyright 2014-2025 SpectroCoin
  * @license https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  */
+
 declare(strict_types=1);
 
 use SpectroCoin\SCMerchantClient\Exception\ApiError;
@@ -66,8 +68,14 @@ class SpectrocoinRedirectModuleFrontController extends ModuleFrontController
             $this->module->client_secret
         );
 
+        $suffix = substr(
+            str_shuffle('0123456789abcdefghijklmnopqrstuvwxyz'),
+            0,
+            5
+        );
+
         $order_data = [
-            'orderId' => $this->module->currentOrder,
+            'orderId' => $this->module->currentOrder . '-' . $suffix,
             'description' => 'Order #' . $this->module->currentOrder,
             'receiveAmount' => $total,
             'receiveCurrencyCode' => $currency->iso_code,


### PR DESCRIPTION
_Added_ support for new JSON and old URL-encoded form data callbacks format. New callbacks will be automatically enabled with new SpectroCoin merchant projects created. With old projects, old callback format will be used. In the future versions old callback format will be removed.